### PR TITLE
Decrease fuel value of wood and electric poles to be consistent with raw-wood

### DIFF
--- a/prototypes/item.lua
+++ b/prototypes/item.lua
@@ -1,4 +1,6 @@
 data.raw["item"]["raw-wood"].fuel_value = "2MJ"
+data.raw["item"]["wood"].fuel_value = "1MJ"
+data.raw["item"]["small-electric-pole"].fuel_value = "2MJ"
 data.raw["item"]["coal"].fuel_value = "4MJ"
 data.raw["item"]["solid-fuel"].fuel_value = "10MJ"
 


### PR DESCRIPTION
Currently, if you break raw-wood down into wood, you double its fuel value.
