### PR TITLE
    Disable gas-canister change, as this inadvertently changes the re…

### DIFF
--- a/prototypes/bobsmods/recipe-resource.lua
+++ b/prototypes/bobsmods/recipe-resource.lua
@@ -11,10 +11,17 @@ Recipe.select("bob-rubber").apply('energy_required', 7).ingredients =
 }
 
 Recipe.select("empty-canister").result_count = 1
+--[[
+The selector in the following line "gas-cansiter" matches
+"petroleum-gas-canister" in bobs, which breaks the recipe - i.e it means you 
+can make a full petrolem-gas-canister from 3 steel beams, instead of from
+a supply of petroleum and an empty gas-canister.
+
 Recipe.select("gas-canister").apply('energy_required', 2).ingredients =
 {
 	{"steel-plate", 3},
 }
+]]
 
 Recipe.select("silicon-wafer").result_count = 6
 


### PR DESCRIPTION
…cipe for petroleum gas canister, because the selector "gas-canister" also selects "petroleum-gas-canister" for update.  A proper fix is required from someone who knows how to write a proper selector, but this workaround should at least make it playable again.